### PR TITLE
Print PR url from stdout if successful

### DIFF
--- a/ai-pr
+++ b/ai-pr
@@ -327,10 +327,14 @@ Please review these changes carefully, focusing on the security implications and
                     ], capture_output=True, text=True)
                     
                     if result.returncode == 0:
-                        print("✅ Draft PR created successfully!")
-                        # Extract PR URL from gh output if available
-                        if result.stderr:
-                            print(result.stderr.strip())
+                        if result.stdout:
+                            url_match = re.search(r'https://github\.com/[^\s]+', result.stdout)
+                            if url_match:
+                                pr_url = url_match.group(0)
+                                print(f"✅ Draft PR created successfully! {pr_url}")
+                            else:
+                                print("✅ Draft PR created successfully!")
+                                print(result.stdout.strip())
                         sys.exit(0)
                     else:
                         print("❌ Failed to create PR", file=sys.stderr)
@@ -399,9 +403,14 @@ Please review these changes carefully, focusing on the security implications and
                     ], capture_output=True, text=True)
                     
                     if result.returncode == 0:
-                        print("✅ Draft PR created successfully with your edits!")
-                        if result.stderr:
-                            print(result.stderr.strip())
+                        if result.stdout:
+                            url_match = re.search(r'https://github\.com/[^\s]+', result.stdout)
+                            if url_match:
+                                pr_url = url_match.group(0)
+                                print(f"✅ Draft PR created successfully with your edits! {pr_url}")
+                            else:
+                                print("✅ Draft PR created successfully with your edits!")
+                                print(result.stdout.strip())
                         sys.exit(0)
                     else:
                         print("❌ Failed to create PR", file=sys.stderr)


### PR DESCRIPTION
With these changes the output for the happy path is now 

> ✅ Draft PR created successfully! https://github.com/foo/bar/pull/1234567

Rationale:
When successful the response is available in stdout not stderr. I opted to search for the URL and add it to the existing print statement over printing the whole output as you get a bit of duplicated confirmation that your PR is created

No strong opinions on what to log, I just want the URL easily accessible afterwards 😄 